### PR TITLE
update bevy to 0.14.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ members = ["examples/video_streaming"]
 resolver = "2"
 
 [dependencies]
-openh264 = {version = "0.3"}
+openh264 = {version = "0.4"}
 serde = "1.0"
 
 [dependencies.bevy]
 default-features = false
 features = ["bevy_asset", "bevy_render"]
-version = "0.13"
+version = "0.14"

--- a/examples/video_streaming/Cargo.toml
+++ b/examples/video_streaming/Cargo.toml
@@ -5,6 +5,6 @@ publish = false
 version = "0.1.0"
 
 [dependencies]
-bevy = "0.13.2"
-bevy_math = "0.13.2"
+bevy = "0.14"
+bevy_math = "0.14"
 bevy_video = {path = "../.."}


### PR DESCRIPTION
This PR updates bevy to 0.14.1

I also had to bump openh264 dependency from 0.3 to 0.4, since the 0.3 won't compile on my system (arch linux) with a link error in openh264-sys2-0.3.2. 

Additionally, I looked into going to the latest openh264 0.6, but didn't manage to get a working version going.